### PR TITLE
Change --socket=x11 to --socket=fallback-x11

### DIFF
--- a/com.github.paolostivanin.OTPClient.yaml
+++ b/com.github.paolostivanin.OTPClient.yaml
@@ -5,7 +5,7 @@ sdk: org.gnome.Sdk
 command: otpclient
 finish-args:
 - "--share=ipc"
-- "--socket=x11"
+- "--socket=fallback-x11"
 - "--socket=wayland"
 - "--device=all"
 - "--talk-name=org.freedesktop.secrets"


### PR DESCRIPTION
Stops gnome-software from showing the "legacy windowing system" warning on systems that would use wayland instead