### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/com.github.paolostivanin.OTPClient.yaml
+++ b/com.github.paolostivanin.OTPClient.yaml
@@ -84,7 +84,6 @@ modules:
   buildsystem: cmake-ninja
   config-opts:
   - "-DCMAKE_BUILD_TYPE=Release"
-  - "-DCMAKE_INSTALL_LIBDIR=lib"
   sources:
   - type: archive
     url: https://github.com/paolostivanin/libcotp/archive/v3.1.1.tar.gz

--- a/com.github.paolostivanin.OTPClient.yaml
+++ b/com.github.paolostivanin.OTPClient.yaml
@@ -11,14 +11,19 @@ finish-args:
 - "--talk-name=org.freedesktop.secrets"
 - "--talk-name=org.gtk.vfs.*"
 - "--filesystem=xdg-run/gvfsd"
+cleanup:
+- /include
+- /lib/cmake
+- /lib/pkgconfig"
+- "*.la"
+- "*.a"
+- /share/doc
+- /share/man
 modules:
 - name: jansson
   cleanup:
-  - "/include"
   - "/bin"
   - "/share"
-  - "/lib/pkgconfig"
-  - "/lib/*.la"
   sources:
   - type: archive
     url: https://github.com/akheron/jansson/releases/download/v2.15.0/jansson-2.15.0.tar.gz
@@ -31,11 +36,8 @@ modules:
   - "-Dprotobuf_BUILD_TESTS=OFF"
   - "-Dprotobuf_ABSL_PROVIDER=package"
   cleanup:
-  - "/include"
   - "/bin"
   - "/share"
-  - "/lib/pkgconfig"
-  - "/lib/*.la"
   sources:
   - type: archive
     url: https://github.com/protocolbuffers/protobuf/releases/download/v25.8/protobuf-25.8.tar.gz
@@ -43,11 +45,8 @@ modules:
 
 - name: protobuf-c
   cleanup:
-  - "/include"
   - "/bin"
   - "/share"
-  - "/lib/pkgconfig"
-  - "/lib/*.la"
   sources:
   - type: archive
     url: https://github.com/protobuf-c/protobuf-c/archive/refs/tags/v1.5.2.tar.gz
@@ -86,8 +85,6 @@ modules:
   config-opts:
   - "-DCMAKE_BUILD_TYPE=Release"
   - "-DCMAKE_INSTALL_LIBDIR=lib"
-  cleanup:
-  - "/include"
   sources:
   - type: archive
     url: https://github.com/paolostivanin/libcotp/archive/v3.1.1.tar.gz


### PR DESCRIPTION
Remove some of development-related folders and files to reduce the Flatpak size.

```
du -ha -d2
24K    ./include/qrencode.h
56K    ./include/zbar.h
68K    ./include/zbar
148K   ./include
520K   ./lib/libjansson.a
204K   ./lib/libprotobuf-c.a
14M    ./lib/libprotobuf-lite.a
100M   ./lib/libprotobuf.a
209M   ./lib/libprotoc.a
12K    ./lib/libutf8_range.a
36K    ./lib/libutf8_validity.a
1,4M   ./lib/libzbar.a
4,0K   ./lib/libzbar.la
56K    ./lib/cmake
12K    ./lib/pkgconfig
72K    ./share/doc
16K    ./share/man

```